### PR TITLE
Widget URL XSS Prevention

### DIFF
--- a/tawkto/readme.txt
+++ b/tawkto/readme.txt
@@ -168,6 +168,7 @@ Note: You will need a free tawk.to account : [Create one for free here!](https:/
 
 = 0.5.0
 * Added option to enable/disable visitor recognition
+* Escaped widget embed URL to prevent possible XSS issues
 
 ## Frequently Asked Questions
 

--- a/tawkto/templates/widget.php
+++ b/tawkto/templates/widget.php
@@ -6,7 +6,7 @@ var Tawk_LoadStart=new Date();
 (function(){
 var s1=document.createElement("script"),s0=document.getElementsByTagName("script")[0];
 s1.async=true;
-s1.src='https://embed.tawk.to/<?php echo $page_id ?>/<?php echo $widget_id ?>';
+s1.src='<?php echo esc_url('https://embed.tawk.to/'.$page_id.'/'.$widget_id); ?>';
 s1.charset='UTF-8';
 s1.setAttribute('crossorigin','*');
 s0.parentNode.insertBefore(s1,s0);


### PR DESCRIPTION
Escaped widget URL to prevent possible XSS issues. This relates to the issue https://github.com/tawk/tawk-wordpress/issues/4