### PR TITLE
fix/pattern-matching-tooltip-display

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "Wordpress plugin for tawk.to",
     "type": "project",
     "license": "GPL-3.0",
-    "version": "0.7.1",
+    "version": "0.7.2",
     "require": {
         "tawk/url-utils": "2.0.1"
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tawk-wordpress",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "tawk.to wordpress plugin",
   "main": "index.js",
   "directories": {

--- a/tawkto/assets/css/tawk.admin.css
+++ b/tawkto/assets/css/tawk.admin.css
@@ -264,6 +264,11 @@ a.tawk-link:hover {
 	top: 5px;
 }
 
+.tooltip.reverse .tooltiptext {
+	top: unset;
+	bottom: 5px;
+}
+
 .tooltip .tooltiptext::before {
 	content: "";
 	display: block;
@@ -276,6 +281,13 @@ a.tawk-link:hover {
 	border-bottom: 5px solid #545454;
 	top: -5px;
 	left: 5px;
+}
+
+.tooltip.reverse .tooltiptext::before {
+	top: unset;
+	border-bottom: unset;
+	bottom: -5px;
+	border-top: 5px solid #545454;
 }
 
 .tooltip:hover .tooltiptext {

--- a/tawkto/assets/js/tawk.admin.js
+++ b/tawkto/assets/js/tawk.admin.js
@@ -62,6 +62,16 @@ jQuery(
 		if ( jQuery( '#exclude-url' ).prop( 'checked' ) ) {
 			jQuery( '#exlucded-urls-container' ).fadeIn();
 		}
+
+		jQuery( '.tooltip' ).on( 'mouseenter', function() {
+			var tooltipTextHeight = jQuery( this ).find( '.tooltiptext' ).height();
+			if ( jQuery( '#url-exclusion' ).height() > tooltipTextHeight ) {
+				jQuery( this ).removeClass( 'reverse' );
+				return;
+			}
+
+			jQuery( this ).addClass( 'reverse' );
+		});
 	}
 );
 

--- a/tawkto/readme.txt
+++ b/tawkto/readme.txt
@@ -3,8 +3,8 @@ Contributors: tawkto
 Tags: tawk,tawk.to,tawkto,chat,free chat,livechat,chat widget,plugin,chat for web,chat online,chat software,free live chat,IM Chat,,live chat,live support,live web chat,online chat,online support,snapengage,wordpress chat,wordpress live chat
 Requires at least: 2.7
 Requires PHP: 5.6
-Tested up to: 5.9
-Stable tag: 0.7.1
+Tested up to: 6.0
+Stable tag: 0.7.2
 
 (OFFICIAL tawk.to plugin) Instantly chat with  visitors on your website with the free tawk.to chat widget.
 Website: [http://tawk.to](http://tawk.to)
@@ -68,6 +68,10 @@ Follow these steps:
 Note: You will need a free tawk.to account: [Create one for free here!](https://tawk.to/?utm_source=wpdirectory&utm_medium=link&utm_campaign=signup)
 
 == Changelog ==
+
+= 0.7.2 =
+* Fixed pattern matching tooltip display.
+* Supported version bump 6.0.
 
 = 0.7.1 =
 * Fixed compatibility issue on PHP versions >= 5.6.

--- a/tawkto/tawkto.php
+++ b/tawkto/tawkto.php
@@ -6,7 +6,7 @@
  * Plugin Name: Tawk.to Live Chat
  * Plugin URI: https://www.tawk.to
  * Description: Embeds Tawk.to live chat widget to your site
- * Version: 0.7.1
+ * Version: 0.7.2
  * Author: Tawkto
  * Text Domain: tawk-to-live-chat
  **/

--- a/tawkto/tawkto.php
+++ b/tawkto/tawkto.php
@@ -162,7 +162,7 @@ if ( ! class_exists( 'TawkTo_Settings' ) ) {
 			if ( true === $settings_updated ) {
 				?>
 				<div class="notice notice-warning is-dismissible">
-					<p><?php esc_html_e( 'You might need to clear cache if your using a cache plugin to see your updates', 'tawk-to-live-chat' ); ?></p>
+					<p><?php esc_html_e( 'You might need to clear cache if you are using a cache plugin to see your updates', 'tawk-to-live-chat' ); ?></p>
 				</div>
 				<?php
 			}

--- a/tawkto/templates/widget.php
+++ b/tawkto/templates/widget.php
@@ -8,7 +8,7 @@
 
 ?>
 
-<!--Start of Tawk.to Script (0.7.1)-->
+<!--Start of Tawk.to Script (0.7.2)-->
 <script id="tawk-script" type="text/javascript">
 var Tawk_API = Tawk_API || {};
 <?php if ( isset( $customer_details ) && $enable_visitor_recognition ) : ?>
@@ -24,4 +24,4 @@ var Tawk_LoadStart=new Date();
 	s0.parentNode.insertBefore( s1, s0 );
 })();
 </script>
-<!--End of Tawk.to Script (0.7.1)-->
+<!--End of Tawk.to Script (0.7.2)-->


### PR DESCRIPTION
Fix for the tooltip display being cut if the remaining space is too little. Also tested the plugin on WordPress 6.0 RC 3

![image](https://user-images.githubusercontent.com/12890893/169494357-cb37906d-b4f5-48d9-93e4-53cccb586195.png)
